### PR TITLE
[Aspa-015] Apache .htaccess URL rewrite to replace manually adding index.php

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,13 +1,29 @@
 <IfModule mod_rewrite.c>
 RewriteEngine on
-RewriteBase /
 
+# ========================================================
+# ====  Uncomment to check if .htaccess is working  ======
+# RewriteRule ^.*$ htaccess_tester.php
+# ========================================================
+
+# ========================================================
+# ====  for assets files =================================
 # Rewrite if the file does not exists
 RewriteCond %{REQUEST_FILENAME} !-f
-
 # Rewrite only if the URI does not starts with assets
 RewriteCond %{REQUEST_URI} !^/assets
-
 # Rewrite any assets file
 RewriteRule ([^/]*).(css|js|png|jpe?g)$ assets/$1.$2 [L]
+# ========================================================
+
+# ========================================================
+# ====  for index.php rewrite  ===========================
+# Rewrite if the file does not exists
+RewriteCond %{REQUEST_FILENAME} !-f
+# Rewrite if the directory does not exists
+RewriteCond %{REQUEST_FILENAME} !-d
+# Rewrite to add index.php
+RewriteRule ^(.*)$ index.php?/$1 [L]
+# ========================================================
+
 </IfModule>

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -114,7 +114,7 @@ $config['enable_hooks'] = FALSE;
 | https://codeigniter.com/user_guide/general/creating_libraries.html
 |
 */
-$config['subclass_prefix'] = 'MY_';
+$config['subclass_prefix'] = 'ASPA_';
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -1,7 +1,8 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class EnrollmentForm extends CI_Controller {
+class EnrollmentForm extends ASPA_Controller 
+{
 
 	function __construct() {
 		parent::__construct();
@@ -22,3 +23,6 @@ class EnrollmentForm extends CI_Controller {
 
 	}
 }
+
+/* End of file EnrollmentForm.php */
+/* Location: ./application/controllers/EnrollmentForm.php */

--- a/application/core/ASPA_Controller.php
+++ b/application/core/ASPA_Controller.php
@@ -1,0 +1,40 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+// Modified base CI controller 
+// So that all controllers can inherit common controller functions
+class ASPA_Controller extends CI_Controller
+{
+
+    function __construct()
+    {
+        parent::__construct();
+        // $this->load->helper();
+		// $this->load->model();
+    }
+
+	/**
+	* This function constructs the json output.
+	*
+	* @param string    	$flag  		To determine if the request was processed successfully
+	* @param string 	$message 	A brief description of the output
+	* @param string 	$extra 		Any extra information
+	*/
+    private function create_json($flag = '', $message = '', $extra = [])
+    {
+        $array = array(
+            'is_success' => $flag,
+            'message' => $message,
+            'extra' => $extra
+        );
+        $this->output
+            ->set_status_header(200)
+            ->set_content_type('application/json')
+            ->set_output(json_encode($array, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES))
+            ->_display();
+        exit;
+    }
+}
+
+/* End of file ASPA_Controller.php */
+/* Location: ./application/controllers/ASPA_Controller.php */

--- a/application/core/ASPA_Controller.php
+++ b/application/core/ASPA_Controller.php
@@ -20,7 +20,7 @@ class ASPA_Controller extends CI_Controller
 	* @param string 	$message 	A brief description of the output
 	* @param string 	$extra 		Any extra information
 	*/
-    private function create_json($flag = '', $message = '', $extra = [])
+    protected function create_json($flag = '', $message = '', $extra = [])
     {
         $array = array(
             'is_success' => $flag,


### PR DESCRIPTION
**Issue**
Controller methods cannot be found through the normal base_url/controller/method URL format. The temporary workaround was to add an "index.php" to activate the Codeigniter front controller before any controller method calls.

This pull request also covers the new project set up of adding another controller to inherit CI system controller class.

**Solution**
Changing the .htaccess file to add a rewrite rule where if the file or directory is not found, redirect to an URL with "index.php" added. This saves all future codes from manually specifying index.php.

For the customizing core controller class, I have extracted another controller layer to inherit CI core system class to put customized reusable controller code in it.

**Risk**
All existing codes that have manually added "index.php" would need a change, as it is suggested to remove the "index.php" part.

**Reviewed** by
Raymond, Jiaru, Daniel