### PR TITLE
[ASPA-011] Google API (automated OS checking)

### DIFF
--- a/application/models/Gsheet_Interface_Model.php
+++ b/application/models/Gsheet_Interface_Model.php
@@ -49,12 +49,12 @@ class Gsheet_Interface_Model extends CI_Model {
     // Finds the current root directory
     function getCurrentWorkingDir()
     {
-        // For Windows
-        //$dir = shell_exec('echo %cd%');
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $dir = shell_exec('echo %cd%');
+        } else {
+            $dir = shell_exec('pwd');
+        }
 
-        // For MacOS / Linux / CentOS server
-        $dir = shell_exec('pwd');
-        
         $stripped = trim($dir);
         return $stripped;
     }


### PR DESCRIPTION
**Issue**
Needed to use different execution commands to find working directory for developers of windows/mac in Gsheet_Interface_Model.php

**Solution**
Automated getWorkingDir() to find directory of current project without having to use comment strings for mac/windows by checking for OS

**Risk area**
Only checks for windows, and assumes everything not windows will use "pwd" command in shell (might not be the case).

**Reviewed by**
Lucas, Martin, Daniel, Will, Jiaru