### PR TITLE
[ASPA-017] Split test spread and membership spreadsheet

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -98,3 +98,5 @@ define('PUBLICKEY', 'pk_test_A4wjqVPPn530rgAXv6sHKgSl00opCMVX9A');
 define('SECRETKEY', 'sk_test_OMC00A11yJUakUU4kx6KoGTp0028EYnLBa');
 
 
+define("MEMBERSHIP_SPREADSHEETID", '10mwPhiOR_Vfsfw8WHereu4Y5KOsuSWkJFGhrf6Mfk9I');
+define("MEMBERSHIP_SHEETNAME", 'Sheet1');

--- a/application/models/Gsheet_Interface_Model.php
+++ b/application/models/Gsheet_Interface_Model.php
@@ -3,19 +3,21 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Gsheet_Interface_Model extends CI_Model {
 
-    private $service = FALSE;
-    private $spreadsheetId = FALSE;
-    private $sheetName = SHEETNAME;
+    private $service = null;
+    private $spreadsheetId = null;
+    private $sheetName = null;
 
     // Setting up current client
-    function __construct($spreadsheetId=SPREADSHEETID)
+    function __construct()
     {
         $this->service = $this->service_setup();
-        $this->spreadsheetId = $spreadsheetId;
+        $this->spreadsheetId = SPREADSHEETID;
+        $this->sheetName = SHEETNAME;
     }
 
-    public function set_spreadsheetId($spreadsheetId) {
+    public function set_spreadsheetId($spreadsheetId, $sheetName=SHEETNAME) {
         $this->spreadsheetId = $spreadsheetId;
+        $this->sheetName = $sheetName;
     }
 
     // Setting up service function

--- a/application/models/Verification_Model.php
+++ b/application/models/Verification_Model.php
@@ -30,7 +30,7 @@ class Verification_Model extends CI_Model {
             return false;
         }
         $this->load->model('Gsheet_Interface_Model');
-        $this->Gsheet_Interface_Model->set_spreadsheetId(SPREADSHEETID);
+        $this->Gsheet_Interface_Model->set_spreadsheetId(MEMBERSHIP_SPREADSHEETID, MEMBERSHIP_SHEETNAME);
         //this gets the sheet size
         $sheetSize = $this->Gsheet_Interface_Model->get_sheet_size();
         //this is an array of array of all existing emails, i.e. [[email1], [email2], [email3]]


### PR DESCRIPTION
**Issue:**
Test spread both acted as event spreadsheet and membership spreadsheet (which was wrong)

**Solution:** 
Made new spreadsheet under WDCC drive "Membership Spread" to simulate ASPA's existing membership.

**Risk areas:**
- Column size of A and B must be the same on membership spread – length of A is used to determine number of spreadsheet records
- On deployment, ensure that defined constants for SPREADSHEETID, SHEETNAME, MEMBERSHIP_SPREADSHEETID, MEMBERSHIP_SHEETNAME are defined and match ASPA's sheets.
- On deployment, ensure to share both files w/ wdcc-aspa google service account (specific acc email can be found by looking at current shared members of test spread).

**Reviewed by:**
Jiaru, Lucas