### PR TITLE
[ASPA-016] Changed Base URL to work with server HTTP host address

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -23,7 +23,12 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | a PHP script and you can easily do that on your own.
 |
 */
-$config['base_url'] = '';
+
+if (substr($_SERVER['HTTP_HOST'], 0, 9) == 'localhost') {
+  $config['base_url'] = $_SERVER['HTTP_HOST'] . '/';
+} else {
+  $config['base_url'] = 'https://' . $_SERVER['HTTP_HOST'] . '/';
+}
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -25,7 +25,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 */
 
 if (substr($_SERVER['HTTP_HOST'], 0, 9) == 'localhost') {
-  $config['base_url'] = $_SERVER['HTTP_HOST'] . '/';
+  $config['base_url'] = "http://" . $_SERVER['HTTP_HOST'] . "/";
 } else {
   $config['base_url'] = 'https://' . $_SERVER['HTTP_HOST'] . '/';
 }

--- a/application/views/PaymentSuccessful.php
+++ b/application/views/PaymentSuccessful.php
@@ -14,14 +14,15 @@
         <meta name='viewport' content='initial-scale=1.0' />
     	<meta name="author" content="UoA Web Development & Consulting Club members">
 
-        <link type='text/css' rel='stylesheet' href='<?php echo base_url(); ?>assets/css/ConfirmationStyle.css' />
+        <base href="/" />
+        <link type='text/css' rel='stylesheet' href='assets/css/ConfirmationStyle.css' />
     </head>
 
     <body>
         <div class="centre-page">
 
             <br />
-            <image id="green-tick" src="<?php echo base_url(); ?>assets/images/Green-Confirmation-Tick.jfif"<?php echo $has_paid ? "" : "style='filter: grayscale(1); -webkit-filter: grayscale(1)'"; ?> />
+            <image id="green-tick" src="assets/images/Green-Confirmation-Tick.jfif"<?php echo $has_paid ? "" : "style='filter: grayscale(1); -webkit-filter: grayscale(1)'"; ?> />
 
             <h1>
                 <?php echo $has_paid ? "Paid!" : "Submitted!"; ?>


### PR DESCRIPTION
Issue: 
CodeIgniter's $config['base_url'] was an automatic process( guessing what root URL was) which is not recommended for production environments. This created an error for Stripe Payment URL redirect which went to the server IP address instead of server directory.

Solution: 
Defined server URL for local development and server production environments (see lines 16 - 20 of config.php).

Risk Area:
Potential path risks with other code attributes. Have tested against the existing master branch, and solves the issue and at this point hasn't caused additional issues.

Reviewed by:
Lucas, Will, Daniel, Martin