### PR TITLE
[ASPA-027] Made the to-be-disabled buttons look and behave like they are disabled

### DIFF
--- a/assets/css/aspa.webflow.css
+++ b/assets/css/aspa.webflow.css
@@ -645,6 +645,12 @@
 	transform: scale(1.1);
 }
 
+.btn-disabled:hover {
+	-webkit-transform: scale(1);
+	-ms-transform: scale(1);
+	transform: scale(1);
+}
+
 .btn-online:active {
 	background-color: #dbdbdb;
 	box-shadow: inset 1px 1px 3px 0 #000, 1px 1px 5px 0 rgba(0, 0, 0, 0.4);

--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -186,6 +186,7 @@ ok3.onclick = function () {
 		data: { emailAddress: emailAddress },
 		// if the validate() url functions correctly (even if it returns True/False), then success function executes.
 		success: function (data) {
+			console.log(data);
 			// data is a JSON object with the following properties:
 			// is_success: True/False (if the email validation succeeeded)
 			// message: any message
@@ -275,7 +276,6 @@ const disabledButtons = [payWeChat, payAli, payPoli];
 [payCash, payTransfer, payWeChat, payAli, payCard, payPoli].forEach(
 	(item, index) => {
 		if (!disabledButtons.includes(item)) {
-			console.log(item);
 			item.addEventListener("click", function (e) {
 				toggleButton(item);
 				showButton(index);

--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -278,7 +278,7 @@ function showWarning() {
 
 /**
  * make the buttons look like they are toggled
- * @param {int} buttonInUse
+ * @param {Object} buttonInUse
  */
 function toggleButton(buttonInUse) {
 	[payCash, payTransfer, payWeChat, payAli, payCard, payPoli].forEach(

--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -186,7 +186,6 @@ ok3.onclick = function () {
 		data: { emailAddress: emailAddress },
 		// if the validate() url functions correctly (even if it returns True/False), then success function executes.
 		success: function (data) {
-			console.log(data);
 			// data is a JSON object with the following properties:
 			// is_success: True/False (if the email validation succeeeded)
 			// message: any message

--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -285,6 +285,31 @@ const disabledButtons = [payWeChat, payAli, payPoli];
 	}
 );
 
+ /*
+	make the to-be-disabled-buttons look like they are disabled 
+	(stopping them from increasing in size when hovered over, reducing their opacity and making them unclickable)
+ */ 
+	disabledButtons.forEach(
+		(buttonToDisable) => {
+			buttonToDisable.classList.add("btn-disabled"); // stopping the disabled buttons from increasing in size when hovered over
+			switch (buttonToDisable) {
+				// More cases need to be added if any other buttons are to be disabled
+				case payWeChat:
+					$(".div-wechatpay").css("opacity", "0.2"); // reducing the opacity
+					$(".btn-online.btn-wechatpay").css("pointer-events", "none"); // making the button unclickable
+					break;
+				case payAli:
+					$(".div-alipay").css("opacity", "0.2");
+					$(".btn-online.btn-alipay").css("pointer-events", "none");
+					break;
+				case payPoli:
+					$(".div-polipay").css("opacity", "0.2");
+					$(".btn-online.btn-polipay").css("pointer-events", "none");
+					break;
+			} 
+		}
+	);
+
 /**
  * make the buttons look like they are toggled
  * @param {Object} buttonInUse

--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -266,13 +266,22 @@ function showWarning() {
 //    Payment Page (page 4) Functionality
 // ==========================================
 
-// sets up event listener for button click
+// Buttons which are to be temporarily disabled
+const disabledButtons = [payWeChat, payAli, payPoli];
+
+/*
+	sets up event listener for button click except for the buttons which are disabled 
+	(the buttons to be disabled will not do anything when clicked on)
+*/
 [payCash, payTransfer, payWeChat, payAli, payCard, payPoli].forEach(
 	(item, index) => {
-		item.addEventListener("click", function (e) {
-			toggleButton(item);
-			showButton(index);
-		});
+		if (!disabledButtons.includes(item)) {
+			console.log(item);
+			item.addEventListener("click", function (e) {
+				toggleButton(item);
+				showButton(index);
+			});
+		}
 	}
 );
 


### PR DESCRIPTION
**Issue:** 
The look and behaviour of the to-be-disabled buttons needed to be changed. A javadoc comment had the wrong parameter.

**Solution:**
A class 'btn-disabled' was added to the classList of the respective buttons. 'btn-disabled' was defined in the aspa.webflow.css file. This stopped the buttons from growing in size when they are hovered over. Also the opacity of the buttons was reduced. The buttons were made visually unclickable. The wrong parameter in the javadoc comment was corrected.

**Risk:** 
None expected

**Reviewed by:**
Raymond Feng, Martin James Tiango, Lucas Gao