### PR TITLE
[ASPA-020] Integrated ASPA-020 changes with multi-event manager (ASPA-024)

### DIFF
--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -33,7 +33,8 @@ class EnrollmentForm extends ASPA_Controller
         if ($this->eventData['gsheet_name']) {
             $this->Gsheet_Interface_Model->set_spreadsheetId(SPREADSHEETID, $this->eventData['gsheet_name']);
         } else {
-            $this->Gsheet_Interface_Model->set_spreadsheetId(SPREADSHEETID, SHEETNAME);
+            // disable form if no event sheet is found.
+            $this->eventData["form_enabled"] = False;
         }
 	}
 

--- a/application/models/Gsheet_Interface_Model.php
+++ b/application/models/Gsheet_Interface_Model.php
@@ -47,6 +47,19 @@ class Gsheet_Interface_Model extends CI_Model {
         }
     }
 
+    function get_sheet_id($sheetName) {
+
+        // Gets all sheets from spreadsheet
+        $sheets = $this->service->spreadsheets->get($this->spreadsheetId)["sheets"];
+
+        // Iterates over sheets, returning first sheetId with matching name
+        foreach ($sheets as $sheet) {
+            if ($sheet['properties']['title'] == $sheetName) {
+                return $sheet['properties']['sheetId'];
+            }
+        }
+    }
+
     // Finds the current root directory
     function getCurrentWorkingDir()
     {
@@ -72,9 +85,8 @@ class Gsheet_Interface_Model extends CI_Model {
             ]
         ];
 
-        echo "<script>console.log(".$this->sheetName.")</script>";
         $formatRange = [
-            "sheetId" => 1497698019,
+            "sheetId" => $this->get_sheet_id($this->sheetName),
             "startRowIndex" => $row_num - 1,
             "endRowIndex" => $row_num,
         ];

--- a/application/models/Gsheet_Interface_Model.php
+++ b/application/models/Gsheet_Interface_Model.php
@@ -12,10 +12,9 @@ class Gsheet_Interface_Model extends CI_Model {
     {
         $this->service = $this->service_setup();
         $this->spreadsheetId = SPREADSHEETID;
-        $this->sheetName = SHEETNAME;
     }
 
-    public function set_spreadsheetId($spreadsheetId, $sheetName=SHEETNAME) {
+    public function set_spreadsheetId($spreadsheetId, $sheetName) {
         $this->spreadsheetId = $spreadsheetId;
         $this->sheetName = $sheetName;
     }

--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -228,7 +228,7 @@ ok3.onclick = function () {
 					data.extra === alreadyPaidForEvent
 				) {
 					showWarning();
-					// change the error message to be "signed up but unpaid" warning
+					// change the error message to be "already paid" warning
 					errorMsgArray[0].innerHTML = alreadyPaidEventErr[0];
 					errorMsgArray[1].innerHTML = alreadyPaidEventErr[1];
 					return;


### PR DESCRIPTION
**Issue:**
Highlighting in Gsheet_Model_Interface was broken due to new event sheets being used and available after the implementation of 020, specifically on how highlighting a row on a specific sheet requires a `sheetId` but we only have variable `sheetName` defined in model class.

**Solution:**
Made a new function `get_sheet_id($sheetName)` that converts `sheetName` to `sheetId`, and uses this to determine which sheet should be highlighted on.

**Risk:**
n/a

**Reviewed by:**
Martin, Lucas, Anubhav

**Other notes:**
Recommended to review changes through 'commit' view instead of 'files changed' view. This allows for a better understanding of work history, and provides context with references in title/summary blocks per commit.