### PR TITLE
[ASPA-035] Directly accessing url ErrorWrapping

### DIFF
--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -183,20 +183,6 @@ class EnrollmentForm extends ASPA_Controller
         }
     }
 
-    public function IEPayPaymentSucessful()
-    {
-
-        //Redirect to the page with green tick
-        $this->load->view('PaymentSuccessful.php',$data);
-
-    }
-
-    public function HighlightGSheet()
-    {
-
-
-    }
-
     public function LoadOfflinePayment()
     {
         $data['has_paid'] = false;

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -100,7 +100,11 @@ class EnrollmentForm extends ASPA_Controller
         $data['name'] = $this->input->post('name');
         $data['email'] = $this->input->post('email');
 
-        $data['session_id'] = "id";
+        // Stopping direct access to this method
+        if (!isset($data['name'])||!isset($data['email']))
+        {
+            show_error("Sorry, this page you are requesting is either not found or you don't have permission to access this page. Error Code:001","404");
+        }
 
         $this->load->model('Gsheet_Interface_Model');
         $this->load->model('Verification_Model');
@@ -170,7 +174,7 @@ class EnrollmentForm extends ASPA_Controller
             $this->load->view('PaymentSuccessful.php', array_merge($this->eventData, $data));
         }
         else {
-            show_error("Something went wrong, your payment wasn't processed correctly. Please contact uoa.wdcc@gmail.com",'001');
+            show_error("Something went wrong, your payment wasn't processed correctly. Please contact uoa.wdcc@gmail.com",'003');
         }
     }
 

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -74,6 +74,10 @@ class EnrollmentForm extends ASPA_Controller
 	public function validate() {
         $emailAddress = $this->input->post('emailAddress');	
 
+        if(!isset($emailAddress)){
+            $this->create_json('False', '', 'Error: Email not specified');
+        }
+
         $this->load->model('Verification_Model');
         
         // has user paid for the event already?

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -99,7 +99,7 @@ class EnrollmentForm extends ASPA_Controller
         $paid_member = ($this->Verification_Model->has_user_paid_membership($data['email']));
         if ( !$paid_member )
         {
-            show_error("Something went wrong, your email was not found in the ASPA member list or havn't paid. Error Code: 002","500");
+            show_error("Something went wrong, your email was not found in the ASPA member list or haven't paid. Error Code: 002","500");
         }
 
         // only record if the email is not found
@@ -140,7 +140,7 @@ class EnrollmentForm extends ASPA_Controller
 
         // Check if there is a session ID, or else redirect back to index
         if (!$data['session_id']) {
-            show_error("Error occured during redirection. If your payment was processed correctly, please contact uoa.wdcc@gmail.com. Error Code: 001","500");
+            show_error("Error occurred during redirection. If your payment was processed correctly, please contact uoa.wdcc@gmail.com. Error Code: 001","500");
         }
 
         // Sets boolean to whether payment was made
@@ -168,7 +168,7 @@ class EnrollmentForm extends ASPA_Controller
             // Highlight this row sicne it is paid
             $this->Gsheet_Interface_Model->highlight_row($row ,[0.69803923, 0.8980392, 0.69803923]);
 
-            // Send a confirmation email only if it wasn't previously highlighed
+            // Send a confirmation email only if it wasn't previously highlighted
             if (!$alreadyHighlighted)
             {
             $this->load->model('EmailModel');

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -146,7 +146,7 @@ class EnrollmentForm extends ASPA_Controller
 
     }
 
-    public function StripePaymentSucessful()
+    public function StripePaymentSuccessful()
     {
         $this->load->model('Stripe_Model');
         $this->load->model('Gsheet_Interface_Model');

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -155,8 +155,7 @@ class EnrollmentForm extends ASPA_Controller
 
         // Check if there is a session ID, or else redirect back to index
         if (!$data['session_id']) {
-            redirect(base_url());
-            return;
+            show_error("Error occured during redirection. If your payment was processed correctly, please contact uoa.wdcc@gmail.com. Error Code: 001","500");
         }
 
         // Sets boolean to whether payment was made

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -208,6 +208,11 @@ class EnrollmentForm extends ASPA_Controller
         $data["email"] = $this->input->post("email");
         $data['paymentMethod'] = $this->input->post("paymentMethod");
 
+        if (!isset($data['name']) || !isset($data["email"]) || !isset($data['paymentMethod'])) 
+        {
+            show_error("Something went wrong. Please contact uoa.wdcc@gmail.com. Error Code: 001","500");
+        }
+
         $this->load->model("Gsheet_Interface_Model");
         $this->load->model("Verification_Model");
 
@@ -219,10 +224,6 @@ class EnrollmentForm extends ASPA_Controller
             // then edit the "How would you like your payment" to be of Offline payment
             // Get the row of the specific email from google sheets
             $cell = $this->Gsheet_Interface_Model->get_cellrange($data['email'], 'B');
-            if (!isset($cell)) 
-            { 
-                show_error("Something went wrong, your email is already registered for the event but seems to have problems. Please contact uoa.wdcc@gmail.com. Error code: 002","500");
-            }
 
             // Split up the cell column and row 
             list(, $row) = $this->Gsheet_Interface_Model->split_column_row($cell);

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -115,7 +115,7 @@ class EnrollmentForm extends ASPA_Controller
         $paid_member = ($this->Verification_Model->has_user_paid_membership($data['email']));
         if ( !$paid_member )
         {
-            show_error("Something went wrong, your email was not found in the ASPA member list or havn't paid","500");
+            show_error("Something went wrong, your email was not found in the ASPA member list or havn't paid. Error Code: 002","500");
         }
 
         // only record if the email is not found
@@ -128,7 +128,7 @@ class EnrollmentForm extends ASPA_Controller
             $cell = $this->Gsheet_Interface_Model->get_cellrange($data['email'], 'B');
             if (!isset($cell)) 
             { 
-                show_error("Something went wrong, your email was not found in the ASPA member list",'002');
+                show_error("Something went wrong, your email was not found in the ASPA member list.Error Code: 002","500");
             }
 
             // Split up the cell column and row 
@@ -171,7 +171,7 @@ class EnrollmentForm extends ASPA_Controller
             $cell = $this->Gsheet_Interface_Model->get_cellrange($data['email'], 'B');
             if (!isset($cell))
             {
-                show_error("Something went wrong, your email was not found in the ASPA member list",'002');
+                show_error("Something went wrong, your email was not found in the ASPA member list. Error Code: 002","500");
             }
 
             // Split up the cell column and row
@@ -183,7 +183,7 @@ class EnrollmentForm extends ASPA_Controller
             $this->load->view('PaymentSuccessful.php', array_merge($this->eventData, $data));
         }
         else {
-            show_error("Something went wrong, your payment wasn't processed correctly. Please contact uoa.wdcc@gmail.com",'003');
+            show_error("Something went wrong, your payment wasn't processed correctly. Please contact uoa.wdcc@gmail.com. Error Code: 003","500");
         }
     }
 
@@ -216,12 +216,12 @@ class EnrollmentForm extends ASPA_Controller
             $this->Gsheet_Interface_Model->record_to_sheet($data['email'], $data['name'], ucfirst($data['paymentMethod']), $data['has_paid']);
         } else {
             // email is found, so find the cell
-            // then edit the "How would you like your payment" to be of Stripe payment
+            // then edit the "How would you like your payment" to be of Offline payment
             // Get the row of the specific email from google sheets
             $cell = $this->Gsheet_Interface_Model->get_cellrange($data['email'], 'B');
             if (!isset($cell)) 
             { 
-                show_error("Something went wrong, your email was not found in the ASPA member list",'002');
+                show_error("Something went wrong, your email is already registered for the event but seems to have problems. Please contact uoa.wdcc@gmail.com. Error code: 002","500");
             }
 
             // Split up the cell column and row 

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -104,16 +104,15 @@ class EnrollmentForm extends ASPA_Controller
         $data['email'] = $this->input->post('email');
 
         // Stopping direct access to this method
-        $paid_member = ($this->Verification_Model->has_user_paid_membership($email));
-        if ( !$paid_member )
-        {
-            show_error("Something went wrong, your email was not found in the ASPA member list","500");
-        }
         if ( !isset($data['name']) || !isset($data['email']) )
         {
             show_error("Sorry, this page you are requesting is either not found or you don't have permission to access this page. Error Code:001","404");
         }
-
+        $paid_member = ($this->Verification_Model->has_user_paid_membership($data['email']));
+        if ( !$paid_member )
+        {
+            show_error("Something went wrong, your email was not found in the ASPA member list or havn't paid","500");
+        }
 
         // only record if the email is not found
         if (!($this->Verification_Model->is_email_on_sheet($data['email'], SPREADSHEETID, $this->eventData['gsheet_name']))) {

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -83,7 +83,7 @@ class EnrollmentForm extends ASPA_Controller
         }
         
         // has user paid for membership?
-		if ($this->Verification_Model->has_user_paid($emailAddress)) {	
+		if ($this->Verification_Model->has_user_paid_membership($emailAddress)) {	
 			$this->create_json('True', '', 'Success');	
 			return;	
 		}	
@@ -96,18 +96,24 @@ class EnrollmentForm extends ASPA_Controller
 
     public function makeStripePayment()
     {
+        $this->load->model('Gsheet_Interface_Model');
+        $this->load->model('Verification_Model');
+
         // Receive data from form, method=POST
         $data['name'] = $this->input->post('name');
         $data['email'] = $this->input->post('email');
 
         // Stopping direct access to this method
-        if (!isset($data['name'])||!isset($data['email']))
+        $paid_member = ($this->Verification_Model->has_user_paid_membership($email));
+        if ( !$paid_member )
+        {
+            show_error("Something went wrong, your email was not found in the ASPA member list","500");
+        }
+        if ( !isset($data['name']) || !isset($data['email']) )
         {
             show_error("Sorry, this page you are requesting is either not found or you don't have permission to access this page. Error Code:001","404");
         }
 
-        $this->load->model('Gsheet_Interface_Model');
-        $this->load->model('Verification_Model');
 
         // only record if the email is not found
         if (!($this->Verification_Model->is_email_on_sheet($data['email'], SPREADSHEETID, $this->eventData['gsheet_name']))) {

--- a/application/models/Stripe_Model.php
+++ b/application/models/Stripe_Model.php
@@ -32,7 +32,7 @@ class Stripe_Model extends CI_Model {
             'currency' => 'NZD',
             'quantity' => 1,
         ]],
-        'success_url' => base_url().'EnrollmentForm/StripePaymentSucessful?session_id={CHECKOUT_SESSION_ID}',
+        'success_url' => base_url().'EnrollmentForm/StripePaymentSuccessful?session_id={CHECKOUT_SESSION_ID}',
         'cancel_url' => base_url(),
         'customer_email' => $customer_email,
 

--- a/application/models/Verification_Model.php
+++ b/application/models/Verification_Model.php
@@ -43,7 +43,6 @@ class Verification_Model extends CI_Model {
         return true;
     }
 
-    // TODO : Refactor this method name to indicate it is has_user_paid_for_membership
     function has_user_paid_membership($emailAddress){
 
         if (!($this->is_email_on_sheet($emailAddress, MEMBERSHIP_SPREADSHEETID, MEMBERSHIP_SHEETNAME))){

--- a/application/models/Verification_Model.php
+++ b/application/models/Verification_Model.php
@@ -43,8 +43,8 @@ class Verification_Model extends CI_Model {
         return true;
     }
 
-
-    function has_user_paid($emailAddress){
+    // TODO : Refactor this method name to indicate it is has_user_paid_for_membership
+    function has_user_paid_membership($emailAddress){
 
         if (!($this->is_email_on_sheet($emailAddress, MEMBERSHIP_SPREADSHEETID, MEMBERSHIP_SHEETNAME))){
             return false;

--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -379,17 +379,6 @@ function showButton(index) {
 
 // TODO: these two buttons must connect to the next step of the enrollment form
 submit.onclick = function () {
-	// send email to the email address the user have inputted using ajax post
-
-	$.ajax({
-		cashe: false,
-		url: base_url + "index.php/EnrollmentForm/send_email",
-		method: "POST",
-		data: { emailAddress: emailAddress, paymentMethod: paymentMethod },
-		success: function (data) {
-			console.log(data);
-		},
-	});
 
 	$("#enrollment-form").attr(
 		"action",


### PR DESCRIPTION
**Issue:**
Directly accessing some of the controller methods will throw a PHP error that is visible to the users. The problem is due to missing GET/POST variables or the logic should not allow direct external access. This issue exists for Stripe Payment successful page and therefore it may also be a problem for all other controller methods. The list of controller methods that need to be checked is
* EnrollmentForm/MakeStripePayment
* EnrollmentForm/send_email
* EnrollmentForm/validate
* EnrollmentForm/StripePaymentSuccessful
* EnrollmentForm/IEPayPaymentSuccessful
* EnrollmentForm/LoadOfflinePayment

**Solution:**
Wrapping a CodeIgniter error if it's missing parameters or the logic appears that the user is directly accessing it.
A wiki page is also made to specify the Error Codes used in the Error pages. [https://github.com/UoaWDCC/ASPA-EnrollmentForm/wiki/Back-End-API-Error-Codes](url)
* EnrollmentForm/MakeStripePayment
* EnrollmentForm/send_email  (REMOVED)
* EnrollmentForm/validate
* EnrollmentForm/StripePaymentSuccessful
* EnrollmentForm/IEPayPaymentSuccessful  (REMOVED)
* EnrollmentForm/LoadOfflinePayment

**Risk:**
Mypay's payment function (MakeMypayPayment) might have the same problem, and needs to be checked.
The send_email controller function has been removed. 

**Reviewed By:**
Raymond