### PR TITLE
[ASPA-016] Configure ASPA Membership SpreadSheet and Add LogViewer

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -244,6 +244,8 @@ $config['log_threshold'] = 2;
 |
 */
 $config['log_path'] = '';
+$config["clv_log_folder_path"] = APPPATH . "logs";
+$config["clv_log_file_pattern"] = "log-*.log";
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -232,7 +232,7 @@ $config['allow_get_array'] = TRUE;
 | your log files will fill up very fast.
 |
 */
-$config['log_threshold'] = 4;
+$config['log_threshold'] = 2;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/production/constants.php
+++ b/application/config/production/constants.php
@@ -24,5 +24,5 @@ if (file_exists($stripeCredentials)) {
 	}
 }
 
-define("MEMBERSHIP_SPREADSHEETID", '10mwPhiOR_Vfsfw8WHereu4Y5KOsuSWkJFGhrf6Mfk9I');
-define("MEMBERSHIP_SHEETNAME", 'Sheet1');
+define("MEMBERSHIP_SPREADSHEETID", '1yS4k6GEhGUcOi1xcOQJ6JrupPQ9jMrqdAe_TC8Pwp84');
+define("MEMBERSHIP_SHEETNAME", 'Form Responses 1');

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -9,11 +9,11 @@ class EnrollmentForm extends ASPA_Controller
     // Function that runs before web page loads
 	function __construct() {
 		parent::__construct();
+        log_message('debug', "=====New Controller Function Initialized====");
 
         // Loading GSIM model into controller
         $this->load->model("Gsheet_Interface_Model");
-
-
+        
         // Get event details from spreadsheet from range A2 to size of spreadsheet;
         $this->Gsheet_Interface_Model->set_spreadsheetId(SPREADSHEETID, "CurrentEventDetails");
         $data = $this->Gsheet_Interface_Model->get_from_sheet('A2', 'C' . ($this->Gsheet_Interface_Model->get_sheet_size() + 2));
@@ -39,8 +39,8 @@ class EnrollmentForm extends ASPA_Controller
 	}
 
 
-	public function index()
-	{
+	public function index()	{
+        log_message('debug', "-- Index Function called");
         if (filter_var($this->eventData["form_enabled"], FILTER_VALIDATE_BOOLEAN)) {
             $this->load->view('EnrollmentForm', $this->eventData);
         } else {
@@ -56,6 +56,7 @@ class EnrollmentForm extends ASPA_Controller
 	 *  - is an email on the email spreadsheet
 	 */
 	public function validate() {
+        log_message('debug', "-- validate function called");
         $emailAddress = $this->input->post('emailAddress');
 
         if(!isset($emailAddress)){
@@ -84,6 +85,7 @@ class EnrollmentForm extends ASPA_Controller
 
     public function makeStripePayment()
     {
+        log_message('debug', "-- makeStripePayment function called");
         $this->load->model('Gsheet_Interface_Model');
         $this->load->model('Verification_Model');
 
@@ -132,6 +134,7 @@ class EnrollmentForm extends ASPA_Controller
 
     public function StripePaymentSuccessful()
     {
+        log_message('debug', "-- StripePaymentSuccessful function called");
         $this->load->model('Stripe_Model');
         $this->load->model('Gsheet_Interface_Model');
         $this->load->model('Verification_Model');
@@ -185,6 +188,7 @@ class EnrollmentForm extends ASPA_Controller
 
     public function LoadOfflinePayment()
     {
+        log_message('debug', "-- LoadOfflinePayment function called");
         $data['has_paid'] = false;
         $data['name'] = $this->input->post("name");
         $data["email"] = $this->input->post("email");

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -10,6 +10,8 @@ class EnrollmentForm extends ASPA_Controller
 	function __construct() {
 		parent::__construct();
         log_message('debug', "=====New Controller Function Initialized====");
+        log_message('debug', "-- from IP address: ". $this->input->ip_address());
+       
 
         // Loading GSIM model into controller
         $this->load->model("Gsheet_Interface_Model");

--- a/application/controllers/LogViewer.php
+++ b/application/controllers/LogViewer.php
@@ -10,10 +10,14 @@ class LogViewer extends CI_Controller
     public function __construct() {
         parent::__construct(); 
         $this->logViewer = new \CILogViewer\CILogViewer();
-        //...
+        log_message('debug', "=====New Log Controller Initialized====");
     }
 
     public function index() {
+        $whitelist = array('127.0.0.1', '::1');
+        if (!in_array($_SERVER['REMOTE_ADDR'], $whitelist)) {
+            show_404('Log page with IP:'.$_SERVER['REMOTE_ADDR'],TRUE);
+        } 
         echo $this->logViewer->showLogs();
         return;
     }

--- a/application/controllers/LogViewer.php
+++ b/application/controllers/LogViewer.php
@@ -1,0 +1,20 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+require_once 'vendor/autoload.php';
+
+class LogViewer extends CI_Controller
+{
+    private $logViewer;
+
+    public function __construct() {
+        parent::__construct(); 
+        $this->logViewer = new \CILogViewer\CILogViewer();
+        //...
+    }
+
+    public function index() {
+        echo $this->logViewer->showLogs();
+        return;
+    }
+}

--- a/application/models/EmailModel.php
+++ b/application/models/EmailModel.php
@@ -262,10 +262,10 @@ class EmailModel extends CI_Model {
         </html>';
 
         try {
-            log_message('info', "=========sending email==============");
+            log_message('debug', "-- sending email");
             $EMAIL_SUBJECT = '"$(echo -e "'.$EMAIL_SUBJECT.'\nContent-Type: text/html'.'")"' ;
             shell_exec("echo '".$message."' | mailx -v -s ".$EMAIL_SUBJECT." ".$EMAIL_RECIEVER." > /dev/null 2>/dev/null &");
-            log_message('info', "=========finish sending email==============");
+            log_message('debug', "-- finish sending email");
         } catch (Exception $e) {
             log_message('error', "sending email failed");
         }

--- a/application/views/cilogviewer/logs.php
+++ b/application/views/cilogviewer/logs.php
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CodeIgniter log viewer</title>
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet"
+          href="https://cdn.datatables.net/plug-ins/9dcbecd42ad/integration/bootstrap/3/dataTables.bootstrap.css">
+
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+    <style>
+        body {
+            padding: 25px;
+        }
+
+        h1 {
+            font-size: 1.5em;
+            margin-top: 0;
+        }
+
+        .date {
+            min-width: 75px;
+        }
+
+        .text {
+            word-break: break-all;
+        }
+
+        a.llv-active {
+            z-index: 2;
+            background-color: #f5f5f5;
+            border-color: #777;
+        }
+    </style>
+</head>
+<body>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-sm-3 col-md-2 sidebar">
+            <h1><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> CodeIgniter Log Viewer</h1>
+            <p class="text-muted"><i>by <a href="https://github.com/SeunMatt" target="_blank">Seun Matt</a></i></p>
+            <div class="list-group">
+                <?php if(empty($files)): ?>
+                    <a class="list-group-item liv-active">No Log Files Found</a>
+                <?php else: ?>
+                    <?php foreach($files as $file): ?>
+                        <a href="?f=<?= base64_encode($file); ?>"
+                           class="list-group-item <?= ($currentFile == $file) ? "llv-active" : "" ?>">
+                            <?= $file; ?>
+                        </a>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+        <div class="col-sm-9 col-md-10 table-container">
+            <?php if(is_null($logs)): ?>
+                <div>
+                    <br><br>
+                    <strong>Log file > 50MB, please download it.</strong>
+                    <br><br>
+                </div>
+            <?php else: ?>
+                <table id="table-log" class="table table-striped">
+                    <thead>
+                    <tr>
+                        <th>Level</th>
+                        <th>Date</th>
+                        <th>Content</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+
+                    <?php foreach($logs as $key => $log): ?>
+                        <tr data-display="stack<?= $key; ?>">
+
+                            <td class="text-<?= $log['class']; ?>">
+                                <span class="<?= $log['icon']; ?>" aria-hidden="true"></span>
+                                &nbsp;<?= $log['level']; ?>
+                            </td>
+                            <td class="date"><?= $log['date']; ?></td>
+                            <td class="text">
+                                <?php if (array_key_exists("extra", $log)): ?>
+                                    <a class="pull-right expand btn btn-default btn-xs"
+                                       data-display="stack<?= $key; ?>">
+                                        <span class="glyphicon glyphicon-search"></span>
+                                    </a>
+                                <?php endif; ?>
+                                <?= $log['content']; ?>
+                                <?php if (array_key_exists("extra", $log)): ?>
+                                    <div class="stack" id="stack<?= $key; ?>"
+                                         style="display: none; white-space: pre-wrap;">
+                                        <?= $log['extra'] ?>
+                                    </div>
+                                <?php endif; ?>
+
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endif; ?>
+            <div>
+                <?php if($currentFile): ?>
+                    <a href="?dl=<?= base64_encode($currentFile); ?>">
+                        <span class="glyphicon glyphicon-download-alt"></span>
+                        Download file
+                    </a>
+                    -
+                    <a id="delete-log" href="?del=<?= base64_encode($currentFile); ?>"><span
+                                class="glyphicon glyphicon-trash"></span> Delete file</a>
+                    <?php if(count($files) > 1): ?>
+                        -
+                        <a id="delete-all-log" href="?del=<?= base64_encode("all"); ?>"><span class="glyphicon glyphicon-trash"></span> Delete all files</a>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/plug-ins/9dcbecd42ad/integration/bootstrap/3/dataTables.bootstrap.js"></script>
+<script>
+    $(document).ready(function () {
+
+        $('.table-container tr').on('click', function () {
+            $('#' + $(this).data('display')).toggle();
+        });
+
+        $('#table-log').DataTable({
+            "order": [],
+            "stateSave": true,
+            "stateSaveCallback": function (settings, data) {
+                window.localStorage.setItem("datatable", JSON.stringify(data));
+            },
+            "stateLoadCallback": function (settings) {
+                var data = JSON.parse(window.localStorage.getItem("datatable"));
+                if (data) data.start = 0;
+                return data;
+            }
+        });
+        $('#delete-log, #delete-all-log').click(function () {
+            return confirm('Are you sure?');
+        });
+    });
+</script>
+</body>
+</html>

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"php": ">=5.3.7",
 		"google/apiclient": "^2.0",
 		"guzzlehttp/guzzle": "~5.3.3",
-		"stripe/stripe-php": "7."
+		"stripe/stripe-php": "7.",
+		"seunmatt/codeigniter-log-viewer": "^1.1"
 	},
 	"suggest": {
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
@@ -24,5 +25,3 @@
 		"phpunit/phpunit": "4.* || 5.*"
 	}
 }
-
-

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b34e6253ace275140a6c6988fb188517",
+    "content-hash": "25c9c2853cb72e885fb72e0aed4f4ec9",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -1039,6 +1039,51 @@
                 "source": "https://github.com/reactphp/promise/tree/v2.8.0"
             },
             "time": "2020-05-12T15:16:56+00:00"
+        },
+        {
+            "name": "seunmatt/codeigniter-log-viewer",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SeunMatt/codeigniter-log-viewer.git",
+                "reference": "94bfe30c9172522352b39b64a85d007028381b5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SeunMatt/codeigniter-log-viewer/zipball/94bfe30c9172522352b39b64a85d007028381b5c",
+                "reference": "94bfe30c9172522352b39b64a85d007028381b5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CILogViewer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Seun Matt",
+                    "email": "smatt382@gmail.com"
+                }
+            ],
+            "description": "This is a simple Log Viewer for viewing Code Igniter log files on the browser",
+            "keywords": [
+                "Code Igniter",
+                "log viewer",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/SeunMatt/codeigniter-log-viewer/issues",
+                "source": "https://github.com/SeunMatt/codeigniter-log-viewer/tree/master"
+            },
+            "time": "2019-09-03T14:50:46+00:00"
         },
         {
             "name": "stripe/stripe-php",


### PR DESCRIPTION
**Issue:**
This pull request covers two features/changes.
The first change is to configure ASPA's Membership SpreadSheet.
The second change is to change up the logging level to prepare for deployment. The logs should be more readable and meaningful. 

**Solution:**
ASPA's Membership SpreadSheet is configured in the constants. LogViewer is added, using a composer package from https://github.com/SeunMatt/codeigniter-log-viewer. 

**Risk:**
Only whitelisted IPs have access to view the logs. Potential risks include user mimicking whitelisted IPs and deleting all the logs.

**Reviewed By:**
James
