### PR TITLE
[ASPA-016] Turn off Membership Payment Check

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -100,3 +100,7 @@ define('SECRETKEY', 'sk_test_OMC00A11yJUakUU4kx6KoGTp0028EYnLBa');
 
 define("MEMBERSHIP_SPREADSHEETID", '10mwPhiOR_Vfsfw8WHereu4Y5KOsuSWkJFGhrf6Mfk9I');
 define("MEMBERSHIP_SHEETNAME", 'Sheet1');
+
+
+// Feature Toggles
+define("CHECK_MEMBERSHIP_PAYMENT", FALSE);

--- a/application/controllers/EnrollmentForm.php
+++ b/application/controllers/EnrollmentForm.php
@@ -73,15 +73,24 @@ class EnrollmentForm extends ASPA_Controller
             return;
         }
 
-        // has user paid for membership?
-		if ($this->Verification_Model->has_user_paid_membership($emailAddress)) {
-			$this->create_json('True', '', 'Success');
-			return;
-		}
-		if ($this->Verification_Model->is_email_on_sheet($emailAddress, MEMBERSHIP_SPREADSHEETID, MEMBERSHIP_SHEETNAME)){
-			$this->create_json('False', '', 'Error: signed up but not paid');
-		} else {
-			$this->create_json('False', '', 'Error: not signed up');
+        // Check if feature toggle for check membership payment is on
+        if (CHECK_MEMBERSHIP_PAYMENT){
+            if ($this->Verification_Model->has_user_paid_membership($emailAddress)) {
+                $this->create_json('True', '', 'Success');
+                return;
+            } else if ($this->Verification_Model->is_email_on_sheet($emailAddress, MEMBERSHIP_SPREADSHEETID, MEMBERSHIP_SHEETNAME)){
+                $this->create_json('False', '', 'Error: signed up but not paid');
+                return;
+            } else {
+                $this->create_json('False', '', 'Error: not signed up');
+                return;
+            }
+        } else { 
+            if ($this->Verification_Model->is_email_on_sheet($emailAddress, MEMBERSHIP_SPREADSHEETID, MEMBERSHIP_SHEETNAME)){
+                $this->create_json('True', '', 'Success');
+            } else {
+                $this->create_json('False', '', 'Error: not signed up');
+            }
         }
 	}
 


### PR DESCRIPTION
**Issue:**
ASPA's membership for this semester is free, so their spreadsheet is not going to be highlighted to indicate paid members. 
This results in the app identifying all members as non-paid members and doesn't let them process further in the registration process.

**Solution:**
Add a feature toggle and implement new logic for verification.

**Risk:**
None

**Reviewed By:**
James