### PR TITLE
[ASPA-016] Make a clickable signup link in the unrecognized prompt

### DIFF
--- a/assets/js/enrollmentForm.js
+++ b/assets/js/enrollmentForm.js
@@ -29,7 +29,7 @@ let errorMsgs = document.getElementsByClassName("div-errormsg");
 let errorMsgArray = document.getElementsByClassName("p-errormessage");
 const notSignedUpUnpaidErr = [
 	"Unrecognized email, please use the email you signed up to ASPA with.",
-	"To sign up: https://bit.ly/3eBrBW5",
+	"To sign up: <a href='https://bit.ly/3eBrBW5' target='_blank'> https://bit.ly/3eBrBW5 </a>", 
 ];
 const signedUpUnpaidErr = [
 	"You have signed up, but have not paid for membership fees.",


### PR DESCRIPTION
**Issue:**
The signup link is not clickable and it makes the user experience less interactive. 

**Solution:**
Add HTML tag in js string

**Risk:**
Not none for now

**Reviewed By:**
Lucas, James
