### PR TITLE
[ASPA-3] Add different registration sheets for DEV/PROD environment

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -94,7 +94,7 @@ defined('EXIT__AUTO_MAX')      OR define('EXIT__AUTO_MAX', 125); // highest auto
 /**
  * The event registration sheet we are storing our information on (i.e. adhoc database).
  */
-const REGISTRATION_SPREADSHEET_ID = '1NJ3gFsf1qP_-5NF2XyistqUzkug99S656I30oa8-iLU';
+const REGISTRATION_SPREADSHEET_ID = '1YvLmK7DbVuf5O3UDKlYaNOH1Zd8ohg_eEibzwfh2IME';
 
 /**
  * Stripe public and private keys for development.

--- a/application/config/production/constants.php
+++ b/application/config/production/constants.php
@@ -25,6 +25,11 @@ if (file_exists($stripeCredentials)) {
 }
 
 /**
+ * Google sheet ID for ASPA's registration spreadsheet.
+ */
+const REGISTRATION_SPREADSHEET_ID = '1NJ3gFsf1qP_-5NF2XyistqUzkug99S656I30oa8-iLU';
+
+/**
  * Google sheet ID and sheet name for ASPA's membership spreadsheet.
  */
 const MEMBERSHIP_SPREADSHEET_ID = '1yS4k6GEhGUcOi1xcOQJ6JrupPQ9jMrqdAe_TC8Pwp84';


### PR DESCRIPTION
**Issue:**
Developers should be testing on a development spreadsheet, not the production spreadsheet.

**Solution:**
We need to create two separate spreadsheets, as well as google credentials for different environments.

**Risk:**
Might need to update the team regarding the processes.

**Reviewed By:**
Lucas