### PR TITLE
[ASPA-6] Add the word *to* in front of event title on title page

### DIFF
--- a/application/views/EnrollmentForm.php
+++ b/application/views/EnrollmentForm.php
@@ -35,7 +35,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
             <div class="div-placeholder"></div>
             <div class="div-main-page-right">
               <h1 class="heading">Welcome</h1>
-              <h1 class="heading-2"><?php echo $title ?></h1>
+              <h1 class="heading-2">To <?php echo $title ?></h1>
               <div class="div-main-page"><a id="register" data-w-id="dfbe5add-65ea-95a7-6380-331c1db905e2" href="#" class="button w-button">Register</a>
                 <p class="paragraph-pressenter">press <strong class="bold-enter">Enter ↵</strong></p>
               </div>


### PR DESCRIPTION
**Issue:**
"To" missing in front of the event title on the home page.

**Solution:**
Added "To" keyword in front of echo title. 

**Risk:**
May have reduced space available for the event title. 

**Reviewed By:**
Raymond Feng
