### PR TITLE
[ASPA-55] Prevent Caching for assests

### DIFF
--- a/application/views/Admin.php
+++ b/application/views/Admin.php
@@ -23,15 +23,15 @@
   <meta name='viewport' content='initial-scale=1.0' />
   <meta name="author" content="UoA Web Development & Consulting Club members">
 
-  <link href="assets/images/favicon.png" rel="icon" type="image/png">
+  <link href="assets/images/favicon.png?random=<?php echo uniqid(); ?>" rel="icon" type="image/png">
 
-  <link href="assets/css/normalize.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/webflow.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/aspa.webflow.css" rel="stylesheet" type="text/css">
+  <link href="assets/css/normalize.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/aspa.webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
 
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" rel="stylesheet" type="text/css">
 
-  <link href="assets/css/admin.css" rel="stylesheet" type="text/css">
+  <link href="assets/css/admin.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
 
   <!-- QR Code Scanning Library -->
   <script type="text/javascript" src="assets/lib/qr-scanner.umd.min.js"></script>

--- a/application/views/EnrollmentForm.php
+++ b/application/views/EnrollmentForm.php
@@ -8,17 +8,17 @@ defined('BASEPATH') OR exit('No direct script access allowed');
   <title>ASPA</title>
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <base href="<?php echo base_url(); ?>" >
-  <link href="assets/css/normalize.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/webflow.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/aspa.webflow.css" rel="stylesheet" type="text/css">
+  <link href="assets/css/normalize.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/aspa.webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
   <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   <script type="text/javascript">WebFont.load({  google: {    families: ["Droid Sans:400,700","PT Serif:400,400italic,700,700italic"]  }});</script>
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
-  <link href="assets/images/favicon.png" rel="icon" type="image/png">
-  <link href="assets/images/webclip.png" rel="apple-touch-icon">
-  <link href="assets/css/enrollmentForm.css" rel="stylesheet">
+  <link href="assets/images/favicon.png?random=<?php echo uniqid(); ?>" rel="icon" type="image/png">
+  <link href="assets/images/webclip.png?random=<?php echo uniqid(); ?>" rel="apple-touch-icon">
+  <link href="assets/css/enrollmentForm.css?random=<?php echo uniqid(); ?>" rel="stylesheet">
 </head>
 <body>
   <div id="base_url" style="display: none;"><?php echo base_url(); ?></div>
@@ -140,8 +140,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
     </div>
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.4.1.min.220afd743d.js?site=5e66056a415f1ee8ad4d7630" type="text/javascript" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-  <script src="assets/js/webflow.js" type="text/javascript"></script>
+  <script src="assets/js/webflow.js?random=<?php echo uniqid(); ?>" type="text/javascript"></script>
   <!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
-  <script src="assets/js/enrollmentForm.js"></script>
+  <script src="assets/js/enrollmentForm.js?random=<?php echo uniqid(); ?>"></script>
 </body>
 </html>

--- a/application/views/FormDisabled.php
+++ b/application/views/FormDisabled.php
@@ -21,11 +21,11 @@
   <meta name='viewport' content='initial-scale=1.0' />
   <meta name="author" content="UoA Web Development & Consulting Club members">
 
-  <link href="assets/css/normalize.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/webflow.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/aspa.webflow.css" rel="stylesheet" type="text/css">
-  <link href='assets/css/formDisabled.css' rel='stylesheet' type='text/css' />
-  <link href="assets/images/favicon.png" rel="icon" type="image/png">
+  <link href="assets/css/normalize.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/aspa.webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href='assets/css/formDisabled.css?random=<?php echo uniqid(); ?>' rel='stylesheet' type='text/css' />
+  <link href="assets/images/favicon.png?random=<?php echo uniqid(); ?>" rel="icon" type="image/png">
 </head>
 
 <body>

--- a/application/views/PaymentSuccessful.php
+++ b/application/views/PaymentSuccessful.php
@@ -14,8 +14,8 @@
     	<meta name="author" content="UoA Web Development & Consulting Club members">
 
         <base href="<?php echo base_url(); ?>" >
-        <link type='text/css' rel='stylesheet' href='assets/css/ConfirmationStyle.css' />
-        <link href="assets/images/favicon.png" rel="icon" type="image/png">
+        <link type='text/css' rel='stylesheet' href='assets/css/ConfirmationStyle.css?random=<?php echo uniqid(); ?>' />
+        <link href="assets/images/favicon.png?random=<?php echo uniqid(); ?>" rel="icon" type="image/png">
     </head>
 
     <body>

--- a/application/views/QrCode.php
+++ b/application/views/QrCode.php
@@ -21,11 +21,11 @@
   <meta name='viewport' content='initial-scale=1.0' />
   <meta name="author" content="UoA Web Development & Consulting Club members">
 
-  <link href="assets/css/normalize.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/webflow.css" rel="stylesheet" type="text/css">
-  <link href="assets/css/aspa.webflow.css" rel="stylesheet" type="text/css">
-  <link href='assets/css/qrCode.css' rel='stylesheet' type='text/css' />
-  <link href="assets/images/favicon.png" rel="icon" type="image/png">
+  <link href="assets/css/normalize.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href="assets/css/aspa.webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+  <link href='assets/css/qrCode.css?random=<?php echo uniqid(); ?>' rel='stylesheet' type='text/css' />
+  <link href="assets/images/favicon.png?random=<?php echo uniqid(); ?>" rel="icon" type="image/png">
 </head>
 
 <body>


### PR DESCRIPTION
**Issue:**
Currently, CSS and JS files (as well as other file types inside the assets folder) are cached, even in the development environment. This makes trying to make changes to the frontend very tedious and hard to manage.

**Solution:**
Adding what so called cache busting (https://curtistimson.co.uk/post/front-end-dev/what-is-cache-busting/) after each js, css, and png files

**Risk:**
None

**Reviewed By:**
Raymond, Matthew, James