### PR TITLE
[ASPA-68] fix https http error with qr link

### DIFF
--- a/application/models/Email_Model.php
+++ b/application/models/Email_Model.php
@@ -62,7 +62,14 @@ class Email_Model extends CI_Model
         }
 
         // QR code url link
-        $QR_CODE_URL = $_SERVER['HTTP_HOST'] . "/qrCode?email=" . $EMAIL_RECEIVER . "&event=" . $EVENT_NAME;
+        // A hacky solution to fix http vs https qr link
+        // if on test environment, use http
+        // else use https for every other server environment
+        if ($_SERVER['HTTP_HOST'] == "localhost") {
+            $QR_CODE_URL = $_SERVER['HTTP_HOST'] . "/qrCode?email=" . $EMAIL_RECEIVER . "&event=" . $EVENT_NAME;
+        } else {
+            $QR_CODE_URL = "https://" . $_SERVER['HTTP_HOST'] . "/qrCode?email=" . $EMAIL_RECEIVER . "&event=" . $EVENT_NAME;
+        }
 
         // Body of email in HTML format (Extracted from mailchimp template)
         // UPDATED NOTE: The new email template is in views/EmailTemplate.php

--- a/application/models/Email_Model.php
+++ b/application/models/Email_Model.php
@@ -65,11 +65,8 @@ class Email_Model extends CI_Model
         // A hacky solution to fix http vs https qr link
         // if on test environment, use http
         // else use https for every other server environment
-        if ($_SERVER['HTTP_HOST'] == "localhost") {
-            $QR_CODE_URL = $_SERVER['HTTP_HOST'] . "/qrCode?email=" . $EMAIL_RECEIVER . "&event=" . $EVENT_NAME;
-        } else {
-            $QR_CODE_URL = "https://" . $_SERVER['HTTP_HOST'] . "/qrCode?email=" . $EMAIL_RECEIVER . "&event=" . $EVENT_NAME;
-        }
+        $QR_CODE_URL = ($_SERVER['HTTP_HOST'] == "localhost" ? "" : "https://")
+                . $_SERVER['HTTP_HOST'] . "/qrCode?email=" . $EMAIL_RECEIVER . "&event=" . $EVENT_NAME;
 
         // Body of email in HTML format (Extracted from mailchimp template)
         // UPDATED NOTE: The new email template is in views/EmailTemplate.php


### PR DESCRIPTION
**Issue:**
http vs https link bug with apple mail

**Solution:**
if statement that decides between which link type (localhost vs aspa.wdcc.co.nz) to send via through.

**Risk:**
testing environments and if the website domain name changes.

**Reviewed By:**
[Edit the message as to who reviewed it here]
