### PR TITLE
[ASPA-48] Fix bug where the response body was not being displayed

### DIFF
--- a/application/core/ASPA_Controller.php
+++ b/application/core/ASPA_Controller.php
@@ -60,7 +60,8 @@ class ASPA_Controller extends CI_Controller
         $this->output
             ->set_status_header($statusCode)
             ->set_content_type('application/json')
-            ->set_output(json_encode($array, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            ->set_output(json_encode($array, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES))
+            ->_display();
         exit;
     }
 


### PR DESCRIPTION
**Issue:**
The response body and payload was not being returned.

**Solution:**
Added `_display()` at the end of output setting inside the `createResponse()` body.

**Risk:**
No risk

**Reviewed By:**
@Metarock 
