### PR TITLE
[ASPA-29] add google analytics track usage

### DIFF
--- a/application/views/EnrollmentForm.php
+++ b/application/views/EnrollmentForm.php
@@ -12,6 +12,26 @@ defined('BASEPATH') or exit('No direct script access allowed');
   <link href="assets/css/normalize.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
   <link href="assets/css/webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
   <link href="assets/css/aspa.webflow.css?random=<?php echo uniqid(); ?>" rel="stylesheet" type="text/css">
+
+  <!-- Google Tag Manager -->
+  <script>
+    (function(w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+      j.async = true;
+      j.src =
+        'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-K52VX6J');
+  </script>
+  <!-- End Google Tag Manager -->
+
   <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   <script type="text/javascript">
@@ -30,27 +50,16 @@ defined('BASEPATH') or exit('No direct script access allowed');
     }(window, document);
   </script>
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-86PRV17BN7"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag('js', new Date());
-
-    gtag('config', 'G-86PRV17BN7', {
-      cookie_flags: 'SameSite=None;Secure'
-    });
-  </script>
-  
   <link href="assets/images/favicon.png?random=<?php echo uniqid(); ?>" rel="icon" type="image/png">
   <link href="assets/images/webclip.png?random=<?php echo uniqid(); ?>" rel="apple-touch-icon">
   <link href="assets/css/enrollmentForm.css?random=<?php echo uniqid(); ?>" rel="stylesheet">
 </head>
 
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K52VX6J" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
   <div id="base_url" style="display: none;"><?php echo base_url(); ?></div>
   <div class="w-form">
     <form action="/" method="post" id="enrollment-form" name="enrollment-form" data-name="Enrollment Form">

--- a/application/views/EnrollmentForm.php
+++ b/application/views/EnrollmentForm.php
@@ -29,6 +29,22 @@ defined('BASEPATH') or exit('No direct script access allowed');
       n.className += t + "js", ("ontouchstart" in o || o.DocumentTouch && c instanceof DocumentTouch) && (n.className += t + "touch")
     }(window, document);
   </script>
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-86PRV17BN7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+
+    gtag('config', 'G-86PRV17BN7', {
+      cookie_flags: 'SameSite=None;Secure'
+    });
+  </script>
+  
   <link href="assets/images/favicon.png?random=<?php echo uniqid(); ?>" rel="icon" type="image/png">
   <link href="assets/images/webclip.png?random=<?php echo uniqid(); ?>" rel="apple-touch-icon">
   <link href="assets/css/enrollmentForm.css?random=<?php echo uniqid(); ?>" rel="stylesheet">


### PR DESCRIPTION
**Issue:**
Require google analytics to track website usage and provide insights. 

**Solution:**
Add google tags manager code snippet into the EnrollmentForm view to the head and body tag with first priority. Google tags manager then communicates and sends data to google analytics to be viewed. Tags and triggers can be managed at https://tagmanager.google.com/

**Risk:**
Google Analytics might be blocked by people's browser extensions. Those extensions may even block people from viewing the site (rare), they could always disable it.

**Reviewed By:**
[Edit the message as to who reviewed it here]
